### PR TITLE
support moving windows to other sessions

### DIFF
--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -278,19 +278,22 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
 
         self.server._update_windows()
 
-    def move_window(self, destination):
+    def move_window(self, destination="", session=None):
         """Move the current :class:`Window` object ``$ tmux move-window``.
 
         :param destination: the ``target window`` or index to move the window
-            to.
-        :type target_window: string
+            to, default: empty string
+        :type destination: string
+        :param session: the ``target session`` or index to move the
+            window to, default: current session.
+        :type session: string
 
         """
-
+        session = session or self.get('session_id')
         proc = self.cmd(
             'move-window',
             '-s%s:%s' % (self.get('session_id'), self.index),
-            '-t%s:%s' % (self.get('session_id'), destination),
+            '-t%s:%s' % (session, destination),
         )
 
         if proc.stderr:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -81,3 +81,10 @@ def test_set_show_environment_single(server, session):
 def test_show_environment_not_set(server):
     """Unset environment variable returns None."""
     assert server.show_environment('BAR') is None
+
+
+def test_new_session(server):
+    """Server.new_session creates and returns valid session"""
+    mysession = server.new_session("test_new_session")
+    assert mysession.get("session_name") == "test_new_session"
+    assert server.has_session("test_new_session")

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -200,3 +200,19 @@ def test_set_window_option_bad(session):
 
     with pytest.raises(exc.UnknownOption):
         window.set_window_option('afewewfew', 43)
+
+
+def test_move_window(session):
+    """Window.move_window results in changed index"""
+
+    window = session.new_window(window_name='test_window')
+    new_index = str(int(window.index) + 1)
+    window.move_window(new_index)
+    assert window.index == new_index
+
+
+def test_move_window_to_other_session(server, session):
+    window = session.new_window(window_name='test_window')
+    new_session = server.new_session("test_move_window")
+    window.move_window(session=new_session.get('session_id'))
+    assert new_session.get_by_id(window.get("window_id")) == window


### PR DESCRIPTION
Added a `session` argument to `Window.move_window`, and supplied a default empty string argument to the `destination` arg.

This allows you to pass a session ID to `Window.move_window`, which will cause the window to change sessions.

I've also updated the tests to include explicit coverage for `Window.move_window` (with and without session moving) and `Server.new_session`.