### PR TITLE
Add start_directory to support to new sessions and panes

### DIFF
--- a/libtmux/pane.py
+++ b/libtmux/pane.py
@@ -103,7 +103,7 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
 
         self.cmd('send-keys', '-R \; clear-history')
 
-    def split_window(self, attach=False, vertical=True):
+    def split_window(self, attach=False, vertical=True, start_directory=None):
         """Split window at pane and return newly created :class:`Pane`.
 
         :param attach: Attach / select pane after creation.
@@ -111,10 +111,14 @@ class Pane(TmuxMappingObject, TmuxRelationalObject):
         :param vertical: split vertically
         :type vertical: bool
         :rtype: :class:`Pane`.
+        :param start_directory: specifies the working directory in which the
+            new pane is created.
+        :type start_directory: string
 
         """
         return self.window.split_window(
             target=self.get('pane_id'),
+            start_directory=start_directory,
             attach=attach,
             vertical=vertical
         )

--- a/libtmux/server.py
+++ b/libtmux/server.py
@@ -401,6 +401,7 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
                     session_name=None,
                     kill_session=False,
                     attach=False,
+                    start_directory=None,
                     *args,
                     **kwargs):
         """Return :class:`Session` from  ``$ tmux new-session``.
@@ -428,6 +429,11 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         :param kill_session: Kill current session if ``$ tmux has-session``
                              Useful for testing workspaces.
         :type kill_session: bool
+
+        :param start_directory: specifies the working directory in which the
+            new session is created.
+        :type start_directory: string
+
         :raises: :exc:`exc.BadSessionName`
         :rtype: :class:`Session`
 
@@ -461,6 +467,8 @@ class Server(TmuxRelationalObject, EnvironmentMixin):
         if not attach:
             tmux_args += ('-d',)
 
+        if start_directory:
+            tmux_args += ('-c', start_directory)
         proc = self.cmd(
             'new-session',
             *tmux_args

--- a/libtmux/session.py
+++ b/libtmux/session.py
@@ -145,7 +145,7 @@ class Session(
 
         :type window_name: string
         :param start_directory: specifies the working directory in which the
-            new created.
+            new window is created.
         :type start_directory: string
         :param attach: make new window the current window after creating it,
                        default True.

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -368,7 +368,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
                        default True.
         :type attach: bool
         :param start_directory: specifies the working directory in which the
-            new created.
+            new window is created.
         :type start_directory: string
         :param target: ``target_pane`` to split.
         :type target: bool


### PR DESCRIPTION
This allows specifying start_directory for creation of both
session and panes.

Clarifies some docstrings as well.