### PR TITLE
Fix error when using is_version with lettered tmux version

### DIFF
--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 from distutils.version import StrictVersion
+from pkg_resources import parse_version
 
 from . import exc
 from ._compat import console_to_str
@@ -387,7 +388,7 @@ def is_version(version):
 
     installed_version = proc.stdout[0].split('tmux ')[1]
 
-    return installed_version == version
+    return parse_version(installed_version) == parse_version(version)
 
 
 def has_required_tmux_version(version=None):

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -10,8 +10,7 @@ import logging
 import os
 import re
 import subprocess
-from distutils.version import StrictVersion
-from pkg_resources import parse_version
+from distutils.version import StrictVersion, LooseVersion
 
 from . import exc
 from ._compat import console_to_str
@@ -388,7 +387,7 @@ def is_version(version):
 
     installed_version = proc.stdout[0].split('tmux ')[1]
 
-    return parse_version(installed_version) == parse_version(version)
+    return LooseVersion(installed_version) == LooseVersion(version)
 
 
 def has_required_tmux_version(version=None):

--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -387,7 +387,7 @@ def is_version(version):
 
     installed_version = proc.stdout[0].split('tmux ')[1]
 
-    return StrictVersion(installed_version) == StrictVersion(version)
+    return installed_version == version
 
 
 def has_required_tmux_version(version=None):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,7 +5,7 @@ import re
 
 import pytest
 
-from libtmux.common import has_required_tmux_version, which, session_check_name
+from libtmux.common import has_required_tmux_version, which, session_check_name, is_version
 from libtmux.exc import LibTmuxException, BadSessionName
 
 version_regex = re.compile(r'[0-9]\.[0-9]')
@@ -32,6 +32,10 @@ def test_ignores_letter_versions():
     result = has_required_tmux_version('1.8a')
     assert result == r'1.8'
 
+    # Should not throw
+    assert type(is_version('1.8'))  is bool
+    assert type(is_version('1.8a')) is bool
+    assert type(is_version('1.9a')) is bool
 
 def test_error_version_less_1_7():
     with pytest.raises(LibTmuxException) as excinfo:


### PR DESCRIPTION
is_version('something') fails with installed tmux 1.9a

To allow tony/tmuxp#197 ;-)