### PR TITLE
Fix has_required_tmux_version when latest tmux HEAD is installed

### DIFF
--- a/libtmux/common.py
+++ b/libtmux/common.py
@@ -412,6 +412,10 @@ def has_required_tmux_version(version=None):
 
         version = proc.stdout[0].split('tmux ')[1]
 
+    # Allow latest tmux HEAD
+    if version == 'master':
+        return version
+
     version = re.sub(r'[a-z]', '', version)
 
     if StrictVersion(version) <= StrictVersion("1.7"):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,12 +8,17 @@ import pytest
 from libtmux.common import has_required_tmux_version, which, session_check_name, is_version
 from libtmux.exc import LibTmuxException, BadSessionName
 
-version_regex = re.compile(r'[0-9]\.[0-9]')
+version_regex = re.compile(r'([0-9]\.[0-9])|(master)')
 
 
 def test_no_arg_uses_tmux_version():
     """Test the :meth:`has_required_tmux_version`."""
     result = has_required_tmux_version()
+    assert version_regex.match(result) is not None
+
+
+def test_allows_master_version():
+    result = has_required_tmux_version('master')
     assert version_regex.match(result) is not None
 
 


### PR DESCRIPTION
When the latest tmux is installed, `tmux -V` returns 'tmux master',
which wasn't properly handled by has_required_tmux_version().

Closes tony/tmuxp#199