### PR TITLE
Retain spaces in quoted strings in window options

### DIFF
--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, unicode_literals, with_statement
 
 import logging
 import os
+import shlex
 
 from . import exc, formats
 from .common import (
@@ -183,7 +184,10 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
                 *tmux_args
             ).stdout
 
-        cmd = [tuple(item.split(' ')) for item in cmd]
+        # The shlex.split function splits the args at spaces, while also
+        # retaining quoted sub-strings.
+        #   shlex.split('this is "a test"') => ['this', 'is', 'a test']
+        cmd = [tuple(shlex.split(item)) for item in cmd]
 
         window_options = dict(cmd)
 

--- a/libtmux/window.py
+++ b/libtmux/window.py
@@ -229,7 +229,7 @@ class Window(TmuxMappingObject, TmuxRelationalObject):
         if not len(cmd.stdout):
             return None
 
-        option = [item.split(' ') for item in cmd.stdout][0]
+        option = [shlex.split(item) for item in cmd.stdout][0]
 
         if option[1].isdigit():
             option = (option[0], int(option[1]))

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -174,6 +174,9 @@ def test_set_show_window_options(session):
     window.set_window_option('main-pane-height', 20)
     assert window.show_window_options('main-pane-height') == 20
 
+    window.set_window_option('pane-border-format', ' #P ')
+    assert window.show_window_options('pane-border-format') == [' #P ']
+
     window.set_window_option('main-pane-height', 40)
     assert window.show_window_options('main-pane-height') == 40
     assert window.show_window_options()['main-pane-height'] == 40

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -174,12 +174,13 @@ def test_set_show_window_options(session):
     window.set_window_option('main-pane-height', 20)
     assert window.show_window_options('main-pane-height') == 20
 
-    window.set_window_option('pane-border-format', ' #P ')
-    assert window.show_window_options('pane-border-format') == [' #P ']
-
     window.set_window_option('main-pane-height', 40)
     assert window.show_window_options('main-pane-height') == 40
     assert window.show_window_options()['main-pane-height'] == 40
+
+    if has_gte_version('2.3'):
+        window.set_window_option('pane-border-format', ' #P ')
+        assert window.show_window_options('pane-border-format') == ' #P '
 
 
 def test_empty_window_option_returns_None(session):


### PR DESCRIPTION
Fixes https://github.com/tony/tmuxp/issues/239

With the below in tmux config:

    setw -g pane-border-format " #P "

Before the fix:

    ('pane-border-format', '"', '#P', '"')

After the fix:

    ('pane-border-format', ' #P ')