### PR TITLE
console_to_str: ignore invalid utf-8

### DIFF
--- a/libtmux/_compat.py
+++ b/libtmux/_compat.py
@@ -42,7 +42,7 @@ if PY2:
         return cls
 
     def console_to_str(s):
-        return s.decode('utf_8')
+        return s.decode('utf_8', 'ignore')
 
 else:
     unichr = chr
@@ -79,9 +79,9 @@ else:
     def console_to_str(s):
         """ From pypa/pip project, pip.backwardwardcompat. License MIT. """
         try:
-            return s.decode(console_encoding)
+            return s.decode(console_encoding, 'ignore')
         except UnicodeDecodeError:
-            return s.decode('utf_8')
+            return s.decode('utf_8', 'ignore')
 
     def reraise(tp, value, tb=None):
         if value.__traceback__ is not tb:


### PR DESCRIPTION
When tmux window title contains invalid utf-8 sequence, libtmux throws exception, for example:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 9: invalid start byte
```

This can be archieved with accidentaly cating binary data to stdout or with
```
$ printf '\033k;\x96\033\'
```

This issue seems to be fixed in tmux (https://github.com/tmux/tmux/commit/8149bc3fa6e93cb083b165a21baa5ec07dd473dc) - title is set only if it is valid utf-8.

Could we fix this issue by ignoring invalid utf-8 sequences directly in function **console_to_str**? 
